### PR TITLE
linter/lintmain: re-consider enable/disable behavior

### DIFF
--- a/linter/lintmain/internal/check/check.go
+++ b/linter/lintmain/internal/check/check.go
@@ -182,26 +182,29 @@ func (l *linter) initCheckers() error {
 		notice := ""
 
 		switch {
-		case disabledByTags(info):
-			notice = "disabled by tags (-disableTags)"
+		case !l.filters.enable.MatchString(info.Name):
+			notice = "not enabled by name (-enable)"
+		case !enabledByTags(info):
+			notice = "not enabled by tags (-enableTags)"
 		case l.filters.disable.MatchString(info.Name):
 			notice = "disabled by name (-disable)"
-		case enabledByTags(info):
-			enabled = true
-			notice = "enabled by tags (-enableTags)"
-		case l.filters.enable.MatchString(info.Name):
-			enabled = true
-			notice = "enabled by name (-enable)"
+		case disabledByTags(info):
+			notice = "disabled by tags (-disableTags)"
 		default:
-			notice = "was not enabled"
+			enabled = true
 		}
 
-		if l.verbose {
+		if l.verbose && !enabled {
 			log.Printf("\tdebug: %s: %s", info.Name, notice)
 		}
 		if enabled {
 			// TODO(Quasilyte): use non-nil params. See #6.
 			l.checkers = append(l.checkers, lintpack.NewChecker(l.ctx, info, nil))
+		}
+	}
+	if l.verbose {
+		for _, c := range l.checkers {
+			log.Printf("\tdebug: %s is enabled", c.Info.Name)
 		}
 	}
 


### PR DESCRIPTION
Replace enable/disable pipeline with:
  (enabledByName(c) && enabledByTags(c)) &&
  (!disabledByName(c) && !disabledByTags(c))

This makes these use-cases trivial:
- enable all, except X
- disable all, except X
- enable only X

Tags provide additional granularity to names and
are used as a groups that help to, for example,
exclude opinionated and experimental checkers.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>