### PR TITLE
add HasTag method to CheckerInfo

### DIFF
--- a/lintpack.go
+++ b/lintpack.go
@@ -30,6 +30,16 @@ type CheckerInfo struct {
 	Note string
 }
 
+// HasTag reports whether checker described by the info has specified tag.
+func (info *CheckerInfo) HasTag(tag string) bool {
+	for i := range info.Tags {
+		if info.Tags[i] == tag {
+			return true
+		}
+	}
+	return false
+}
+
 // Warning represents issue that is found by checker.
 type Warning struct {
 	// Node is an AST node that caused warning to trigger.


### PR DESCRIPTION
Makes checking for common tags like "experimental" easier:
```
	info.HasTag("experimental")
	info.HasTag("opinionated")
```
Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>