### PR TITLE
all: ship subcommands with usage examples

### DIFF
--- a/cmd/lintpack/build.go
+++ b/cmd/lintpack/build.go
@@ -65,8 +65,10 @@ func (p *packer) parseArgs() error {
 		flag.PrintDefaults()
 	}
 
-	flag.StringVar(&p.Config.Version, "linterVersion", "0.0.1",
+	flag.StringVar(&p.Config.Version, "linter.version", "0.0.1",
 		`value that will be printed by the linter "version" command`)
+	flag.StringVar(&p.Config.Name, "linter.name", "linter",
+		`name associated with linter`)
 	flag.StringVar(&p.flags.outputFilename, "o", "linter",
 		`produced binary filename`)
 
@@ -76,6 +78,9 @@ func (p *packer) parseArgs() error {
 
 	if len(p.flags.args) == 0 {
 		return errors.New("not enough arguments: expected non-empty package list")
+	}
+	if p.Config.Name == "" {
+		return errors.New("-linter.name can't be empty")
 	}
 
 	return nil

--- a/cmd/lintpack/main.go
+++ b/cmd/lintpack/main.go
@@ -19,11 +19,17 @@ var subCommands = []*cmdutil.SubCommand{
 		Main:  lintpackBuild,
 		Name:  "build",
 		Short: "build linter from made of lintpack-compatible packages",
+		Examples: []string{
+			"lintpack build -help",
+			"lintpack build -o gocritic github.com/go-critic/checkers",
+			"lintpack build -linter.version=v1.0.0 .",
+		},
 	},
 	{
-		Main:  lintpackVersion,
-		Name:  "version",
-		Short: "print lintpack version",
+		Main:     lintpackVersion,
+		Name:     "version",
+		Short:    "print lintpack version",
+		Examples: []string{"lintpack version"},
 	},
 }
 

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -15,6 +15,9 @@ type SubCommand struct {
 
 	// Short describes command in one line of text.
 	Short string
+
+	// Examples shows one or more sub-command execution examples.
+	Examples []string
 }
 
 // DispatchCommand runs sub command out of specified cmdList based on
@@ -62,5 +65,8 @@ func printSubCommands(cmdList []*SubCommand) {
 	log.Println("Supported sub-commands:")
 	for _, cmd := range cmdList {
 		log.Printf("\t%s - %s", cmd.Name, cmd.Short)
+		for i := range cmd.Examples {
+			log.Printf("\t\t$ %s", cmd.Examples[i])
+		}
 	}
 }

--- a/linter/lintmain/lintmain.go
+++ b/linter/lintmain/lintmain.go
@@ -2,6 +2,7 @@ package lintmain
 
 import (
 	"log"
+	"strings"
 
 	"github.com/go-lintpack/lintpack/internal/cmdutil"
 	"github.com/go-lintpack/lintpack/linter/lintmain/internal/check"
@@ -10,6 +11,7 @@ import (
 // Config is used to parametrize the linter.
 type Config struct {
 	Version string
+	Name    string
 }
 
 var config *Config
@@ -19,20 +21,37 @@ var config *Config
 func Run(cfg Config) {
 	config = &cfg // TODO(quasilyte): don't use global var for this
 	log.SetFlags(0)
-	cmdutil.DispatchCommand(subCommands)
-}
 
-var subCommands = []*cmdutil.SubCommand{
-	{
-		Main:  check.Main,
-		Name:  "check",
-		Short: "run linter over specified targets",
-	},
-	{
-		Main:  printVersion,
-		Name:  "version",
-		Short: "print linter version",
-	},
+	// makeExample replaces all ${linter} placeholders to a bound linter name.
+	makeExamples := func(examples ...string) []string {
+		from := "${linter} "
+		to := cfg.Name + " "
+		for i := range examples {
+			examples[i] = strings.Replace(examples[i], from, to, 1)
+		}
+		return examples
+	}
+
+	subCommands := []*cmdutil.SubCommand{
+		{
+			Main:  check.Main,
+			Name:  "check",
+			Short: "run linter over specified targets",
+			Examples: makeExamples(
+				"${linter} check -help",
+				"${linter} check -disableTags=none strings bytes",
+				"${linter} check -enableTags=diagnostic ./...",
+			),
+		},
+		{
+			Main:     printVersion,
+			Name:     "version",
+			Short:    "print linter version",
+			Examples: makeExamples("${linter} version"),
+		},
+	}
+
+	cmdutil.DispatchCommand(subCommands)
 }
 
 func printVersion() {

--- a/linter/lintmain/lintmain.go
+++ b/linter/lintmain/lintmain.go
@@ -1,8 +1,8 @@
 package lintmain
 
 import (
+	"fmt"
 	"log"
-	"strings"
 
 	"github.com/go-lintpack/lintpack/internal/cmdutil"
 	"github.com/go-lintpack/lintpack/linter/lintmain/internal/check"
@@ -24,10 +24,8 @@ func Run(cfg Config) {
 
 	// makeExample replaces all ${linter} placeholders to a bound linter name.
 	makeExamples := func(examples ...string) []string {
-		from := "${linter} "
-		to := cfg.Name + " "
 		for i := range examples {
-			examples[i] = strings.Replace(examples[i], from, to, 1)
+			examples[i] = fmt.Sprintf(examples[i], cfg.Name)
 		}
 		return examples
 	}
@@ -38,16 +36,16 @@ func Run(cfg Config) {
 			Name:  "check",
 			Short: "run linter over specified targets",
 			Examples: makeExamples(
-				"${linter} check -help",
-				"${linter} check -disableTags=none strings bytes",
-				"${linter} check -enableTags=diagnostic ./...",
+				"%s check -help",
+				"%s check -disableTags=none strings bytes",
+				"%s check -enableTags=diagnostic ./...",
 			),
 		},
 		{
 			Main:     printVersion,
 			Name:     "version",
 			Short:    "print linter version",
-			Examples: makeExamples("${linter} version"),
+			Examples: makeExamples("%s version"),
 		},
 	}
 


### PR DESCRIPTION
Also add linter.name flag for lintpack build,
so the linter can have bound name that is not
affected by a binary name.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>