### PR TITLE
add CheckerCollection type and enforce its usage

### DIFF
--- a/lintpack.go
+++ b/lintpack.go
@@ -11,7 +11,7 @@ import (
 
 // CheckerCollection provides additional information for a group of checkers.
 type CheckerCollection struct {
-	// URL describes a link for a main source of information on the collection.
+	// URL is a link for a main source of information on the collection.
 	URL string
 }
 


### PR DESCRIPTION
Instead of making AddChecker call, one needs to
create an CheckerCollection instance and call
AddChecker method on that. This way, all checkers
are associated to some collection.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>