### PR TITLE
linter/lintmain: fix plugin loading

### DIFF
--- a/linter/lintmain/internal/check/check.go
+++ b/linter/lintmain/internal/check/check.go
@@ -247,7 +247,9 @@ func (l *linter) loadProgram() error {
 }
 
 func (l *linter) loadPlugin() error {
-	return hotload.CheckersFromDylib(l.pluginPath)
+	infoList, err := hotload.CheckersFromDylib(l.infoList, l.pluginPath)
+	l.infoList = infoList
+	return err
 }
 
 type boundCheckerParams struct {

--- a/linter/lintmain/internal/hotload/hotload.go
+++ b/linter/lintmain/internal/hotload/hotload.go
@@ -8,19 +8,23 @@ import (
 )
 
 // CheckersFromDylib loads checkers provided by a dynamic lybrary found under path.
-func CheckersFromDylib(path string) error {
+//
+// The returned info slice must be re-assigned to the original info slice,
+// since there will be new entries there.
+func CheckersFromDylib(infoList []*lintpack.CheckerInfo, path string) ([]*lintpack.CheckerInfo, error) {
 	if path == "" {
-		return nil // Nothing to do
+		return infoList, nil // Nothing to do
 	}
-	checkersBefore := len(lintpack.GetCheckersInfo())
+	checkersBefore := len(infoList)
 	// Open plugin only for side-effects (init functions).
 	_, err := plugin.Open(path)
 	if err != nil {
-		return err
+		return infoList, err
 	}
-	checkersAfter := len(lintpack.GetCheckersInfo())
+	maybeUpdatedList := lintpack.GetCheckersInfo()
+	checkersAfter := len(maybeUpdatedList)
 	if checkersBefore == checkersAfter {
-		return fmt.Errorf("loaded plugin doesn't provide any lintpack-compatible checkers")
+		return infoList, fmt.Errorf("loaded plugin doesn't provide any lintpack-compatible checkers")
 	}
-	return nil
+	return maybeUpdatedList, nil
 }


### PR DESCRIPTION
When dylib is loaded, we need to re-assign info list.
Otherwise, cached l.infoList will not contain info
about dynamically loaded checkers.

Updates #36

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>