### PR TITLE
linttest: change tests comment directive format

### DIFF
--- a/checkers/testdata/panicNil/positive_tests.go
+++ b/checkers/testdata/panicNil/positive_tests.go
@@ -2,12 +2,12 @@ package checker_test
 
 func nilPanics() {
 	_ = func() {
-		/// panic(nil) calls are discouraged
+		/*! panic(nil) calls are discouraged */
 		panic(nil)
 	}
 
 	_ = func() {
-		/// panic(interface{}(nil)) calls are discouraged
+		/*! panic(interface{}(nil)) calls are discouraged */
 		panic(interface{}(nil))
 	}
 }

--- a/linttest/end2end.go
+++ b/linttest/end2end.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	warningDirectiveRE = regexp.MustCompile(`^\s*/// (.*)`)
+	warningDirectiveRE = regexp.MustCompile(`^\s*/\*! (.*) \*/`)
 	commentRE          = regexp.MustCompile(`^\s*//`)
 )
 
@@ -25,6 +25,8 @@ func (w warning) String() string {
 	return w.text
 }
 
+// TODO(Quasilyte): rename the function and a type.
+// The're not related to a golden file.
 func newGoldenFile(t *testing.T, filename string) *goldenFile {
 	testData, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -40,11 +42,6 @@ func newGoldenFile(t *testing.T, filename string) *goldenFile {
 			pending = append(pending, &warning{text: m[1]})
 		} else if len(pending) != 0 {
 			line := i + 1
-			if commentRE.MatchString(l) {
-				// Hack to make it possible to attach directives
-				// to a proper single-line comment position.
-				line -= len(pending)
-			}
 			warnings[line] = append([]*warning{}, pending...)
 			pending = pending[:0]
 		}


### PR DESCRIPTION
From:
  /// The magic comment
To:
  /*! The magic comment */

It makes it possible to distinguish directive comments
easier and avoids formatting issues.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>