### PR TITLE
linttest: make it possible to filter tests with -run

### DIFF
--- a/linttest/linttest.go
+++ b/linttest/linttest.go
@@ -22,7 +22,7 @@ func saneCheckersList(t *testing.T) []*lintpack.CheckerInfo {
 
 	for _, info := range lintpack.GetCheckersInfo() {
 		pkgPath := "github.com/go-lintpack/lintpack/linttest/testdata/sanity"
-		t.Run("sanity/"+info.Name, func(t *testing.T) {
+		t.Run(info.Name+"/sanity", func(t *testing.T) {
 			fset := token.NewFileSet()
 			pkgs := newPackages(t, pkgPath, fset)
 			for _, pkg := range pkgs {


### PR DESCRIPTION
The problem is that sanity tests do not match patterns
like -run=/underef. To avoid that, switch from
/sanity/underef to /underef/sanity format.
This way, sanity tests match given pattern and everything
works as expected.

Fixes #53

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>