### PR TITLE
linter/lintmain: update usage examples

### DIFF
--- a/linter/lintmain/internal/check/check.go
+++ b/linter/lintmain/internal/check/check.go
@@ -339,7 +339,7 @@ func (l *linter) parseArgs() error {
 		`whether to replace error location prefix with $GOROOT and $GOPATH`)
 	flag.BoolVar(&l.coloredOutput, `coloredOutput`, false,
 		`whether to use colored output`)
-	flag.BoolVar(&l.verbose, `verbose`, false,
+	flag.BoolVar(&l.verbose, "v", false,
 		`whether to print output useful during linter debugging`)
 
 	flag.Parse()

--- a/linter/lintmain/lintmain.go
+++ b/linter/lintmain/lintmain.go
@@ -38,8 +38,8 @@ func Run(cfg Config) {
 			Short: "run linter over specified targets",
 			Examples: makeExamples(
 				"%s check -help",
-				"%s check -disableTags=none strings bytes",
-				"%s check -enableTags=diagnostic ./...",
+				"%s check -enable='paramTypeCombine,unslice' strings bytes",
+				"%s check -v -enable='#diagnostic' -disable='#experimental,#opinionated' ./...",
 			),
 		},
 		{


### PR DESCRIPTION
Also rename -verbose flag to just -v.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>