### PR TITLE
linttest: disable Go modules inside integration tests

### DIFF
--- a/linttest/integration.go
+++ b/linttest/integration.go
@@ -93,7 +93,12 @@ func (cfg *IntegrationTest) runTest(t *testing.T, linter, gopath string) {
 		// Get the actual execution output.
 		cmd := exec.Command(linter, runParams...)
 		cmd.Env = append([]string{}, os.Environ()...) // Copy parent env
-		cmd.Env = append(cmd.Env, "GOPATH="+gopath)   // Override GOPATH
+		cmd.Env = append(cmd.Env,
+			// Override GOPATH.
+			"GOPATH="+gopath,
+			// Disable modules. See #62.
+			"GO111MODULE=off")
+
 		out, err := cmd.CombinedOutput()
 		out = bytes.TrimSpace(out)
 		var have string


### PR DESCRIPTION
Fixes #62

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>