### PR TITLE
cmd/lintpack/build: close a file before remove call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test ci
 
+export GO111MODULE := on
+
 %:      # stubs to get makefile param for `test-checker` command
 	@:	# see: https://stackoverflow.com/a/6273809/433041
 

--- a/cmd/lintpack/build.go
+++ b/cmd/lintpack/build.go
@@ -19,6 +19,9 @@ func lintpackBuild() {
 
 	defer func() {
 		if p.main != nil {
+			if err := p.main.Close(); err != nil {
+				return // We tried
+			}
 			if err := os.Remove(p.main.Name()); err != nil {
 				log.Printf("cleanup failed: %v", err)
 			}


### PR DESCRIPTION
This is especially important for Windows.

Fixes #66

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>